### PR TITLE
Add <External /> and external() methods to manage async triggers. Add a blacklist for triggers.

### DIFF
--- a/demo/03-submachines/src/index.js
+++ b/demo/03-submachines/src/index.js
@@ -103,7 +103,8 @@ class Demo extends React.Component {
                                   data: editedNum,
                                   go,
                                   transition,
-                                  update
+                                  update,
+                                  external
                                 }) => {
                                   return (
                                     <div className="block edit">
@@ -132,13 +133,22 @@ class Demo extends React.Component {
                                       <button
                                         data-test={"async-clear-" + idx}
                                         onClick={e => {
-                                          setTimeout(
+                                          external(
+                                            "delayed timer",
+                                            () =>
+                                              setTimeout(
+                                                () =>
+                                                  update(
+                                                    "Mode.Edit",
+                                                    data => data + "!!!"
+                                                  ),
+                                                2000
+                                              ),
                                             () =>
                                               update(
                                                 "Mode.Edit",
                                                 data => data + "!!!"
-                                              ),
-                                            1000
+                                              )
                                           );
                                         }}
                                       >

--- a/demo/03-submachines/src/index.js
+++ b/demo/03-submachines/src/index.js
@@ -104,7 +104,8 @@ class Demo extends React.Component {
                                   go,
                                   transition,
                                   update,
-                                  external
+                                  external,
+                                  External
                                 }) => {
                                   return (
                                     <div className="block edit">
@@ -142,7 +143,7 @@ class Demo extends React.Component {
                                                     "Mode.Edit",
                                                     data => data + "!!!"
                                                   ),
-                                                2000
+                                                1000
                                               ),
                                             () =>
                                               update(
@@ -152,7 +153,13 @@ class Demo extends React.Component {
                                           );
                                         }}
                                       >
-                                        Exclaim!
+                                        Exclaim!{" "}
+                                        <External
+                                          name="delayed timer"
+                                          fallback={<span>sync</span>}
+                                        >
+                                          <span>async</span>
+                                        </External>
                                       </button>
                                       <button
                                         data-test={"cancel-mode-" + idx}

--- a/demo/03-submachines/src/index.js
+++ b/demo/03-submachines/src/index.js
@@ -51,7 +51,7 @@ class Demo extends React.Component {
       return (
         <External
           name="delayed timer"
-          fallback={<Transition key={new Date()} to="Visibility.Hide" />}
+          fallback={<Transition to="Visibility.Hide" />}
         >
           <div>Timer enabled</div>
         </External>

--- a/demo/03-submachines/src/index.js
+++ b/demo/03-submachines/src/index.js
@@ -1,6 +1,13 @@
 import React from "react";
 import { render } from "react-dom";
-import { Machinate, States, State, Submachine, withState } from "machinate";
+import {
+  Machinate,
+  States,
+  State,
+  Submachine,
+  withState,
+  withMachine
+} from "machinate";
 import { Inspector } from "machinate-plugins-inspector";
 
 class Demo extends React.Component {
@@ -40,6 +47,16 @@ class Demo extends React.Component {
   }
   render() {
     const WhenVisibleHoC = withState("Visibility.Show", () => <span>All</span>);
+    const MachineTest = withMachine(({ External, Transition }) => {
+      return (
+        <External
+          name="delayed timer"
+          fallback={<Transition key={new Date()} to="Visibility.Hide" />}
+        >
+          <div>Timer enabled</div>
+        </External>
+      );
+    });
     return (
       <Machinate
         scheme={this.scheme}
@@ -53,6 +70,7 @@ class Demo extends React.Component {
           <State for="Visibility.Hide">{() => <span>Hidden</span>}</State>
           <WhenVisibleHoC />
         </h2>
+        <MachineTest />
         <States
           for="Items"
           List={({ data, go }) => (

--- a/src/components/External.js
+++ b/src/components/External.js
@@ -1,0 +1,22 @@
+import { Component } from "react";
+import PropTypes from "prop-types";
+
+class External extends Component {
+  render() {
+    return (
+      (this.props.checkBlacklisted(this.props.name)
+        ? this.props.fallback && {
+            ...this.props.fallback,
+            key: this.context.lastForceTime
+          }
+        : this.props.children) || null
+    );
+  }
+}
+
+export default External;
+
+External.contextTypes = {
+  machine: PropTypes.object,
+  lastForceTime: PropTypes.any
+};

--- a/src/components/External.js
+++ b/src/components/External.js
@@ -7,7 +7,7 @@ class External extends Component {
       (this.props.checkBlacklisted(this.props.name)
         ? this.props.fallback && {
             ...this.props.fallback,
-            key: this.context.lastForceTime
+            key: this.props.fallback.key || this.context.lastForceTime
           }
         : this.props.children) || null
     );

--- a/src/components/Machinate.js
+++ b/src/components/Machinate.js
@@ -29,7 +29,8 @@ class Machinate extends React.Component {
     return {
       machine: this.state.machine,
       scope: [],
-      forced: !!this.forced
+      forced: !!this.forced,
+      lastForceTime: this.state.machine.lastForceTime()
     };
   }
   createMachine(scheme, initialState) {
@@ -49,7 +50,8 @@ Machinate.propTypes = {
 Machinate.childContextTypes = {
   machine: PropTypes.object,
   scope: PropTypes.array,
-  forced: PropTypes.bool
+  forced: PropTypes.bool,
+  lastForceTime: PropTypes.any
 };
 
 Machinate.contextTypes = {

--- a/src/components/State.js
+++ b/src/components/State.js
@@ -1,23 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
-class Transition extends Component {
-  componentWillMount() {
-    this.props.transition(this.props.to, this.props.data);
-  }
-  render() {
-    return this.props.children || null;
-  }
-}
-class External extends Component {
-  render() {
-    return (
-      (this.props.checkBlacklisted(this.props.name)
-        ? this.props.fallback
-        : this.props.children) || null
-    );
-  }
-}
+import Transition from "./Transition";
+import External from "./External";
 
 class State extends Component {
   isUnmounted = false;
@@ -29,7 +13,10 @@ class State extends Component {
       context.scope,
       this.isActive
     );
-
+    this.persistentMethods = this.context.machine.scoped(
+      context.scope,
+      () => true
+    );
     this.Transition = ({ ...props }) => (
       <Transition transition={this.transientMethods.transition} {...props} />
     );
@@ -62,9 +49,7 @@ class State extends Component {
     return stateInfo;
   };
   render() {
-    const { machine: { external }, scope } = this.context;
-
-    const persistentMethods = this.context.machine.scoped(scope, () => true);
+    const { machine: { external } } = this.context;
 
     const stateInfo = this.getActiveState();
     if (!stateInfo) return null;
@@ -74,8 +59,8 @@ class State extends Component {
         data: stateInfo.data,
         ...this.transientMethods,
         persistent: {
-          ...persistentMethods
-        }, // always transition
+          ...this.persistentMethods
+        },
 
         external: external(this.scoped),
 

--- a/src/components/State.js
+++ b/src/components/State.js
@@ -9,6 +9,15 @@ class Transition extends Component {
     return this.props.children || null;
   }
 }
+class External extends Component {
+  render() {
+    return (
+      (this.props.checkBlacklisted(this.props.name)
+        ? this.props.fallback
+        : this.props.children) || null
+    );
+  }
+}
 
 class State extends Component {
   isUnmounted = false;
@@ -23,6 +32,12 @@ class State extends Component {
 
     this.Transition = ({ ...props }) => (
       <Transition transition={this.transientMethods.transition} {...props} />
+    );
+    this.External = ({ ...props }) => (
+      <External
+        checkBlacklisted={context.machine.isTriggerBlacklisted}
+        {...props}
+      />
     );
   }
   isActive = () => {
@@ -64,7 +79,8 @@ class State extends Component {
 
         external: external(this.scoped),
 
-        Transition: this.Transition
+        Transition: this.Transition,
+        External: this.External
       }) || null
     );
   }

--- a/src/components/Transition.js
+++ b/src/components/Transition.js
@@ -1,0 +1,12 @@
+import { Component } from "react";
+
+class Transition extends Component {
+  componentWillMount() {
+    this.props.transition(this.props.to, this.props.data);
+  }
+  render() {
+    return this.props.children || null;
+  }
+}
+
+export default Transition;

--- a/src/machine.js
+++ b/src/machine.js
@@ -278,7 +278,8 @@ const createMachine = function(schema, state) {
   const log = msg => emitter.emit("log", msg);
 
   let blacklist = [];
-  const isBlacklisted = name => blacklist.some(regex => !!name.match(regex));
+  const isTriggerBlacklisted = name =>
+    blacklist.some(regex => !!name.match(regex));
 
   const executeScoped = (isActive, transient) => {
     return !transient || isActive();
@@ -301,11 +302,12 @@ const createMachine = function(schema, state) {
     }),
 
     external: fnArgs => (name, promise, fallback = () => {}) =>
-      isBlacklisted(name) ? fallback(fnArgs) : promise(fnArgs),
+      isTriggerBlacklisted(name) ? fallback(fnArgs) : promise(fnArgs),
     setBlacklist: newBlacklist => {
       blacklist = newBlacklist;
     },
     getBlacklist: () => blacklist,
+    isTriggerBlacklisted,
 
     getDomainInfo,
     componentForDomain,

--- a/src/machine.js
+++ b/src/machine.js
@@ -14,6 +14,7 @@ import eventemitter from "./emitter";
 const createMachine = function(schema, state) {
   let components = [];
   const submachines = [];
+  let lastForceTime = new Date();
   const emitter = eventemitter();
 
   if (!schema) {
@@ -47,6 +48,7 @@ const createMachine = function(schema, state) {
 
   const setState = nextState => {
     state = nextState;
+    lastForceTime = new Date();
     emitter.emit("force-state", { state });
   };
 
@@ -288,6 +290,7 @@ const createMachine = function(schema, state) {
   const createdMachine = {
     getState,
     setState,
+    lastForceTime: () => lastForceTime,
 
     transition,
     go,
@@ -306,6 +309,7 @@ const createMachine = function(schema, state) {
       isTriggerBlacklisted(name) ? fallback(fnArgs) : promise(fnArgs),
     setBlacklist: newBlacklist => {
       blacklist = newBlacklist;
+      setState(getState());
     },
     getBlacklist: () => blacklist,
     isTriggerBlacklisted,

--- a/src/machine.js
+++ b/src/machine.js
@@ -281,7 +281,7 @@ const createMachine = function(schema, state) {
   const isTriggerBlacklisted = name =>
     blacklist.some(regex => !!name.match(regex));
 
-  const executeScoped = (isActive, transient) => {
+  const shouldExecuteScoped = (isActive, transient) => {
     return !transient || isActive();
   };
 
@@ -295,10 +295,11 @@ const createMachine = function(schema, state) {
 
     scoped: (scope, isActive = () => true, transient = true) => ({
       transition: (...args) =>
-        executeScoped(isActive, transient) && transition(scope, ...args),
-      go: (...args) => executeScoped(isActive, transient) && go(scope, ...args),
+        shouldExecuteScoped(isActive, transient) && transition(scope, ...args),
+      go: (...args) =>
+        shouldExecuteScoped(isActive, transient) && go(scope, ...args),
       update: (...args) =>
-        executeScoped(isActive, transient) && update(scope, ...args)
+        shouldExecuteScoped(isActive, transient) && update(scope, ...args)
     }),
 
     external: fnArgs => (name, promise, fallback = () => {}) =>


### PR DESCRIPTION
- Move globalTransition to persistent.[transition(), update(), go()]
- Change the transient methods to be dependent on component lifecycle (proxy for "is state active"?) instead of an on-demand lookup of active state, to prevent navigating away, coming back, and still having the trigger take effect.